### PR TITLE
Various cleanups

### DIFF
--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -6,7 +6,6 @@ use warnings;
 use Net::Pcap;
 use Proc::Daemon;
 use Socket;
-use constant DUMMY_ADDR  => scalar(sockaddr_in(0, inet_aton('1.0.0.0')));
 
 Proc::Daemon::Init;
 
@@ -35,7 +34,9 @@ sub process_packet {
     $packet = unpack("x16a*", $packet);
 
     my $dest_ip = unpack("x16a4", $packet);
-    send($socket, $packet, 0, DUMMY_ADDR) or die "Couldn't send packet: $!";
+    if (!send($socket, $packet, 0, pack_sockaddr_in(0, $dest_ip))) {
+        die "Couldn't send packet: $!";
+    }
     print "Sent to $dest_ip\n";
 }
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -15,7 +15,7 @@ my $continue = 1;
 socket(RAW, AF_INET, SOCK_RAW, 255) || die $!;
 setsockopt(RAW, 0, 1, 1);
 my $dev = $ARGV[0];
-# open the device for live listening
+
 my $pcap = Net::Pcap::open_live($dev, 1024, 0, 0, \$err);
 $filter="proto gre";
 if ( Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1 ) {
@@ -25,7 +25,6 @@ if ( Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1 ) {
 Net::Pcap::setfilter($pcap,$filter_t);
 Net::Pcap::loop($pcap, -1 , \&process_packet, "just for the demo");
 
-# close the device
 Net::Pcap::close($pcap);
 
 sub process_packet {
@@ -35,6 +34,5 @@ sub process_packet {
     print "Sending $packet to $pkt->{'dest_ip'}\n";
     send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";
     print "Sent to $pkt->{'dest_ip'}\n";
-    # do something ...
 }
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -36,8 +36,9 @@ sub process_packet {
     $packet = unpack("x16a*", $packet);
 
     my $pkt = NetPacket::IP->decode($packet);
-    print "Sending $packet to $pkt->{'dest_ip'}\n";
+    my $dest_ip = $pkt->{'dest_ip'};
+    print "Sending $packet to $dest_ip\n";
     send($socket, $packet, 0, DUMMY_ADDR) or die "Couldn't send packet: $!";
-    print "Sent to $pkt->{'dest_ip'}\n";
+    print "Sent to $dest_ip\n";
 }
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -30,11 +30,11 @@ my $continue = 1;
 
     sub process_packet {
         my ($user_data, $header, $packet) = @_;
-	my $packet = unpack("x16a*",$packet);
+        my $packet = unpack("x16a*",$packet);
         my $pkt = NetPacket::IP->decode($packet);
-	print "Sending $packet to $pkt->{'dest_ip'}\n";
-	send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";
+        print "Sending $packet to $pkt->{'dest_ip'}\n";
+        send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";
         print "Sent to $pkt->{'dest_ip'}\n";
-	# do something ...
+        # do something ...
     }
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -35,7 +35,6 @@ sub process_packet {
     $packet = unpack("x16a*", $packet);
 
     my $dest_ip = unpack("x16a4", $packet);
-    print "Sending $packet to $dest_ip\n";
     send($socket, $packet, 0, DUMMY_ADDR) or die "Couldn't send packet: $!";
     print "Sent to $dest_ip\n";
 }

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -20,7 +20,7 @@ my $pcap = Net::Pcap::open_live($dev, 1024, 0, 0, \$err);
 
 my $filter = "proto gre";
 my $filter_t;
-if (Net::Pcap::compile($pcap, \$filter_t, $filter, 0, 0) == -1) {
+if (Net::Pcap::compile($pcap, \$filter_t, $filter, 1, 0) == -1) {
     die "Unable to compile filter string '$filter'\n";
 }
 Net::Pcap::setfilter($pcap, $filter_t);

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -1,4 +1,8 @@
 #!/usr/bin/perl
+
+use strict;
+use warnings;
+
 use Net::Pcap;
 use NetPacket::IP;
 use Proc::Daemon;
@@ -11,10 +15,12 @@ socket(RAW, AF_INET, SOCK_RAW, 255) || die $!;
 setsockopt(RAW, 0, 1, 1);
 
 my $dev = $ARGV[0];
+my $err;
 my $pcap = Net::Pcap::open_live($dev, 1024, 0, 0, \$err);
 
-$filter = "proto gre";
-if (Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1) {
+my $filter = "proto gre";
+my $filter_t;
+if (Net::Pcap::compile($pcap, \$filter_t, $filter, 0, 0) == -1) {
     die "Unable to compile filter string '$filter'\n";
 }
 Net::Pcap::setfilter($pcap, $filter_t);
@@ -25,7 +31,7 @@ Net::Pcap::close($pcap);
 
 sub process_packet {
     my ($user_data, $header, $packet) = @_;
-    my $packet = unpack("x16a*", $packet);
+    $packet = unpack("x16a*", $packet);
     my $pkt = NetPacket::IP->decode($packet);
     print "Sending $packet to $pkt->{'dest_ip'}\n";
     send(RAW, $packet, 0, DUMMY_ADDR) or die "Couldn't send packet: $!";

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -1,16 +1,12 @@
 #!/usr/bin/perl
 use Net::Pcap;
 use NetPacket::IP;
-use FileHandle;
 use Socket;
 use constant DUMMY_ADDR  => scalar(sockaddr_in(0, inet_aton('1.0.0.0')));
 
 use Proc::Daemon;
 
 Proc::Daemon::Init;
-
-my $continue = 1;
-#$SIG{TERM} = sub { $continue = 0 };
 
 socket(RAW, AF_INET, SOCK_RAW, 255) || die $!;
 setsockopt(RAW, 0, 1, 1);
@@ -23,7 +19,7 @@ if (Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1) {
 }
 
 Net::Pcap::setfilter($pcap, $filter_t);
-Net::Pcap::loop($pcap, -1, \&process_packet, "just for the demo");
+Net::Pcap::loop($pcap, -1, \&process_packet, undef);
 
 Net::Pcap::close($pcap);
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -33,8 +33,8 @@ my $continue = 1;
 	my $packet = unpack("x16a*",$packet);
         my $pkt = NetPacket::IP->decode($packet);
 	print "Sending $packet to $pkt->{'dest_ip'}\n";
-	send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";	
-        print "Sent to $pkt->{'dest_ip'}\n"; 
+	send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";
+        print "Sent to $pkt->{'dest_ip'}\n";
 	# do something ...
     }
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -12,29 +12,29 @@ Proc::Daemon::Init;
 my $continue = 1;
 #$SIG{TERM} = sub { $continue = 0 };
 
-    socket(RAW, AF_INET, SOCK_RAW, 255) || die $!;
-    setsockopt(RAW, 0, 1, 1);
-    my $dev = $ARGV[0];
-    # open the device for live listening
-    my $pcap = Net::Pcap::open_live($dev, 1024, 0, 0, \$err);
-    $filter="proto gre";
-    if ( Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1 ) {
-        die "Unable to compile filter string '$filter'\n";
-    }
+socket(RAW, AF_INET, SOCK_RAW, 255) || die $!;
+setsockopt(RAW, 0, 1, 1);
+my $dev = $ARGV[0];
+# open the device for live listening
+my $pcap = Net::Pcap::open_live($dev, 1024, 0, 0, \$err);
+$filter="proto gre";
+if ( Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1 ) {
+    die "Unable to compile filter string '$filter'\n";
+}
 
-    Net::Pcap::setfilter($pcap,$filter_t);
-    Net::Pcap::loop($pcap, -1 , \&process_packet, "just for the demo");
+Net::Pcap::setfilter($pcap,$filter_t);
+Net::Pcap::loop($pcap, -1 , \&process_packet, "just for the demo");
 
-    # close the device
-    Net::Pcap::close($pcap);
+# close the device
+Net::Pcap::close($pcap);
 
-    sub process_packet {
-        my ($user_data, $header, $packet) = @_;
-        my $packet = unpack("x16a*",$packet);
-        my $pkt = NetPacket::IP->decode($packet);
-        print "Sending $packet to $pkt->{'dest_ip'}\n";
-        send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";
-        print "Sent to $pkt->{'dest_ip'}\n";
-        # do something ...
-    }
+sub process_packet {
+    my ($user_data, $header, $packet) = @_;
+    my $packet = unpack("x16a*",$packet);
+    my $pkt = NetPacket::IP->decode($packet);
+    print "Sending $packet to $pkt->{'dest_ip'}\n";
+    send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";
+    print "Sent to $pkt->{'dest_ip'}\n";
+    # do something ...
+}
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -31,7 +31,10 @@ Net::Pcap::close($pcap);
 
 sub process_packet {
     my ($user_data, $header, $packet) = @_;
+
+    # Strip the "cooked capture" header.
     $packet = unpack("x16a*", $packet);
+
     my $pkt = NetPacket::IP->decode($packet);
     print "Sending $packet to $pkt->{'dest_ip'}\n";
     send(RAW, $packet, 0, DUMMY_ADDR) or die "Couldn't send packet: $!";

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -1,10 +1,9 @@
 #!/usr/bin/perl
 use Net::Pcap;
 use NetPacket::IP;
+use Proc::Daemon;
 use Socket;
 use constant DUMMY_ADDR  => scalar(sockaddr_in(0, inet_aton('1.0.0.0')));
-
-use Proc::Daemon;
 
 Proc::Daemon::Init;
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -17,22 +17,22 @@ setsockopt(RAW, 0, 1, 1);
 my $dev = $ARGV[0];
 
 my $pcap = Net::Pcap::open_live($dev, 1024, 0, 0, \$err);
-$filter="proto gre";
-if ( Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1 ) {
+$filter = "proto gre";
+if (Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1) {
     die "Unable to compile filter string '$filter'\n";
 }
 
-Net::Pcap::setfilter($pcap,$filter_t);
-Net::Pcap::loop($pcap, -1 , \&process_packet, "just for the demo");
+Net::Pcap::setfilter($pcap, $filter_t);
+Net::Pcap::loop($pcap, -1, \&process_packet, "just for the demo");
 
 Net::Pcap::close($pcap);
 
 sub process_packet {
     my ($user_data, $header, $packet) = @_;
-    my $packet = unpack("x16a*",$packet);
+    my $packet = unpack("x16a*", $packet);
     my $pkt = NetPacket::IP->decode($packet);
     print "Sending $packet to $pkt->{'dest_ip'}\n";
-    send(RAW,$packet,0,DUMMY_ADDR) or die "Couldn't send packet: $!";
+    send(RAW, $packet, 0, DUMMY_ADDR) or die "Couldn't send packet: $!";
     print "Sent to $pkt->{'dest_ip'}\n";
 }
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -37,6 +37,5 @@ sub process_packet {
     if (!send($socket, $packet, 0, pack_sockaddr_in(0, $dest_ip))) {
         die "Couldn't send packet: $!";
     }
-    print "Sent to $dest_ip\n";
 }
 

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -9,15 +9,16 @@ Proc::Daemon::Init;
 
 socket(RAW, AF_INET, SOCK_RAW, 255) || die $!;
 setsockopt(RAW, 0, 1, 1);
-my $dev = $ARGV[0];
 
+my $dev = $ARGV[0];
 my $pcap = Net::Pcap::open_live($dev, 1024, 0, 0, \$err);
+
 $filter = "proto gre";
 if (Net::Pcap::compile($pcap, \$filter_t, $filter, $opt, $net) == -1) {
     die "Unable to compile filter string '$filter'\n";
 }
-
 Net::Pcap::setfilter($pcap, $filter_t);
+
 Net::Pcap::loop($pcap, -1, \&process_packet, undef);
 
 Net::Pcap::close($pcap);

--- a/gre-keepalive.pl
+++ b/gre-keepalive.pl
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Net::Pcap;
-use NetPacket::IP;
 use Proc::Daemon;
 use Socket;
 use constant DUMMY_ADDR  => scalar(sockaddr_in(0, inet_aton('1.0.0.0')));
@@ -35,8 +34,7 @@ sub process_packet {
     # Strip the "cooked capture" header.
     $packet = unpack("x16a*", $packet);
 
-    my $pkt = NetPacket::IP->decode($packet);
-    my $dest_ip = $pkt->{'dest_ip'};
+    my $dest_ip = unpack("x16a4", $packet);
     print "Sending $packet to $dest_ip\n";
     send($socket, $packet, 0, DUMMY_ADDR) or die "Couldn't send packet: $!";
     print "Sent to $dest_ip\n";


### PR DESCRIPTION
I split these out into pretty small chunks, in case you agree with some but disagree with others.

The most significant change is using the real destination IP when calling send().

Note that when I was running this, I actually had Proc::Daemon commented out. (I didn't commit that, though.) So it's possible that one of my changes could break this when Proc::Daemon is used.
